### PR TITLE
Fix GPU incompatibility on Intel Macs; add GPU toggle; fix piper/python3 path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,11 +16,23 @@ echo "  Raju — Local Voice Assistant — Installer"
 echo "══════════════════════════════════════════"
 echo ""
 
-# ── 1. macOS check ─────────────────────────────────────────────────────────────
+# ── 1. macOS check + GPU detection ────────────────────────────────────────────
 if [[ "$(uname)" != "Darwin" ]]; then
   fail "Raju requires macOS."
 fi
 ok "macOS detected ($(sw_vers -productVersion))"
+
+ARCH=$(uname -m)
+mkdir -p "$HOME/.raju"
+if [[ "$ARCH" == "arm64" ]]; then
+  ok "Apple Silicon (arm64) — GPU acceleration enabled by default"
+  echo "true"  > "$HOME/.raju/use_gpu"
+  CMAKE_GPU_FLAGS="-DGGML_METAL=ON"
+else
+  warn "Intel Mac detected — GPU disabled by default (Metal compatibility issue)"
+  echo "false" > "$HOME/.raju/use_gpu"
+  CMAKE_GPU_FLAGS="-DGGML_METAL=OFF"
+fi
 
 # ── 2. Xcode Command Line Tools (for swiftc) ──────────────────────────────────
 if ! command -v swiftc &>/dev/null; then
@@ -49,10 +61,10 @@ ok "sox (rec at $(which rec))"
 LLAMA_DIR="$HOME/local_llms/llama.cpp"
 LLAMA_BIN="$LLAMA_DIR/build/bin/llama-server"
 if [[ ! -f "$LLAMA_BIN" ]]; then
-  warn "llama.cpp not found — building from source with Metal support…"
+  warn "llama.cpp not found — building from source…"
   mkdir -p "$HOME/local_llms"
   git clone https://github.com/ggerganov/llama.cpp "$LLAMA_DIR"
-  cmake -B "$LLAMA_DIR/build" -S "$LLAMA_DIR" -DGGML_METAL=ON -DCMAKE_BUILD_TYPE=Release
+  cmake -B "$LLAMA_DIR/build" -S "$LLAMA_DIR" $CMAKE_GPU_FLAGS -DCMAKE_BUILD_TYPE=Release
   cmake --build "$LLAMA_DIR/build" --config Release -j4
 fi
 ok "llama-server at $LLAMA_BIN"
@@ -61,10 +73,10 @@ ok "llama-server at $LLAMA_BIN"
 WHISPER_DIR="$HOME/local_llms/whisper.cpp"
 WHISPER_BIN="$WHISPER_DIR/build/bin/whisper-server"
 if [[ ! -f "$WHISPER_BIN" ]]; then
-  warn "whisper.cpp not found — building from source with Metal support…"
+  warn "whisper.cpp not found — building from source…"
   mkdir -p "$HOME/local_llms"
   git clone https://github.com/ggerganov/whisper.cpp "$WHISPER_DIR"
-  cmake -B "$WHISPER_DIR/build" -S "$WHISPER_DIR" -DGGML_METAL=ON
+  cmake -B "$WHISPER_DIR/build" -S "$WHISPER_DIR" $CMAKE_GPU_FLAGS
   cmake --build "$WHISPER_DIR/build" -j4
 fi
 ok "whisper-server at $WHISPER_BIN"
@@ -96,11 +108,33 @@ VOICES_DIR="$HOME/.raju/voices"
 PIPER_MODEL="$VOICES_DIR/en_US-lessac-medium.onnx"
 mkdir -p "$VOICES_DIR"
 
-if ! python3 -c "import piper" &>/dev/null; then
-  info "Installing piper-tts via pip3…"
-  pip3 install piper-tts 2>&1 | tail -3
+# Find a python3 that has pip, preferring the one already in PATH
+PYTHON3_BIN=""
+for candidate in "$(which python3 2>/dev/null)" \
+                 /opt/homebrew/bin/python3 \
+                 /usr/local/bin/python3 \
+                 /usr/bin/python3; do
+  if [[ -x "$candidate" ]] && "$candidate" -m pip --version &>/dev/null 2>&1; then
+    PYTHON3_BIN="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$PYTHON3_BIN" ]]; then
+  warn "No python3 with pip found — Piper TTS unavailable; will use macOS 'say' for speech"
+else
+  # Install piper-tts if not already present
+  if ! "$PYTHON3_BIN" -c "import piper" &>/dev/null 2>&1; then
+    info "Installing piper-tts for $PYTHON3_BIN…"
+    "$PYTHON3_BIN" -m pip install piper-tts 2>&1 | tail -5
+  fi
+  if "$PYTHON3_BIN" -c "import piper" &>/dev/null 2>&1; then
+    echo "$PYTHON3_BIN" > "$HOME/.raju/python3_bin"
+    ok "piper-tts installed ($PYTHON3_BIN)"
+  else
+    warn "piper-tts install failed — will use macOS 'say' for speech"
+  fi
 fi
-ok "piper-tts (python3 -m piper)"
 
 if [[ ! -f "$PIPER_MODEL" ]]; then
   info "Downloading Piper voice model (en_US-lessac-medium, ~60 MB)…"

--- a/main.swift
+++ b/main.swift
@@ -8,7 +8,17 @@ let WHISPER_SERVER = "\(HOME)/local_llms/whisper.cpp/build/bin/whisper-server"
 let WHISPER_MODEL  = "\(HOME)/local_llms/whisper.cpp/models/ggml-small.bin"
 let LLAMA_SERVER   = "\(HOME)/local_llms/llama.cpp/build/bin/llama-server"
 let REC_BIN        = "/usr/local/bin/rec"
-let PYTHON3_BIN    = "/usr/local/bin/python3"
+let PYTHON3_BIN: String = {
+    // Read path written by installer; fall back to common locations
+    let configPath = "\(HOME)/.raju/python3_bin"
+    if let path = try? String(contentsOfFile: configPath, encoding: .utf8)
+                            .trimmingCharacters(in: .whitespacesAndNewlines),
+       !path.isEmpty, FileManager.default.fileExists(atPath: path) { return path }
+    for p in ["/usr/local/bin/python3", "/opt/homebrew/bin/python3", "/usr/bin/python3"] {
+        if FileManager.default.fileExists(atPath: p) { return p }
+    }
+    return "/usr/local/bin/python3"
+}()
 let PIPER_OUT      = "/tmp/raju_tts.wav"
 let SAY_BIN        = "/usr/bin/say"
 let AUDIO_FILE     = "/tmp/raju_input.wav"
@@ -21,6 +31,19 @@ let LLAMA_PORT     = 8080
 let WHISPER_PORT   = 8081
 let LLAMA_URL      = "http://127.0.0.1:\(LLAMA_PORT)"
 let WHISPER_URL    = "http://127.0.0.1:\(WHISPER_PORT)"
+
+// ── GPU preference ────────────────────────────────────────────────────────────
+// Persisted in UserDefaults; installer writes ~/.raju/use_gpu based on CPU type.
+// Auto-detect fallback: Apple Silicon (arm64) → GPU on; Intel → GPU off.
+var useGPU: Bool {
+    get {
+        if let pref = UserDefaults.standard.object(forKey: "useGPU") as? Bool { return pref }
+        if let val = try? String(contentsOfFile: "\(HOME)/.raju/use_gpu", encoding: .utf8)
+                             .trimmingCharacters(in: .whitespacesAndNewlines) { return val == "true" }
+        return shell("/usr/bin/uname", ["-m"]).trimmed == "arm64"
+    }
+    set { UserDefaults.standard.set(newValue, forKey: "useGPU") }
+}
 
 // ── Logger ────────────────────────────────────────────────────────────────────
 // Serial queue keeps concurrent log() calls from interleaving bytes mid–emoji
@@ -68,7 +91,7 @@ enum RajuState {
 // ── TTS — piper (python3 -m piper) if model exists, fallback to say ──────────
 func speak(_ text: String, modelPath: String) {
     let fm = FileManager.default
-    if fm.fileExists(atPath: modelPath) {
+    if fm.fileExists(atPath: modelPath) && fm.fileExists(atPath: PYTHON3_BIN) {
         let piper = Process()
         piper.executableURL = URL(fileURLWithPath: PYTHON3_BIN)
         piper.arguments = ["-m", "piper", "--model", modelPath, "--output_file", PIPER_OUT]
@@ -649,6 +672,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let itemStatus       = NSMenuItem(title: "",                      action: nil,                                    keyEquivalent: "")
     let itemQuery        = NSMenuItem(title: "",                      action: nil,                                    keyEquivalent: "")
     let itemReply        = NSMenuItem(title: "",                      action: nil,                                    keyEquivalent: "")
+    let itemGPUToggle    = NSMenuItem(title: "  ⚡ GPU: On",           action: #selector(toggleGPU),                   keyEquivalent: "")
     let itemLaunchAtLogin = NSMenuItem(title: "  Launch at Login",    action: #selector(toggleLaunchAtLogin),         keyEquivalent: "")
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -690,6 +714,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         itemLlamaToggle.target   = self
         itemWhisperToggle.target = self
+        itemGPUToggle.target     = self
+        itemGPUToggle.title      = useGPU ? "  ⚡ GPU: On" : "  ⚪ GPU: Off"
         itemLaunchAtLogin.target = self
         itemLaunchAtLogin.state  = isLaunchAtLoginEnabled() ? .on : .off
 
@@ -702,6 +728,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(NSMenuItem.separator())
         menu.addItem(itemModel)
         menu.addItem(itemVoice)
+        menu.addItem(itemGPUToggle)
         menu.addItem(itemHint)
         menu.addItem(itemStatus)
         menu.addItem(NSMenuItem.separator())
@@ -750,7 +777,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         log("🚀 Starting llama-server (\(model.name)) on :\(LLAMA_PORT)…")
         llamaProcess = Process()
         llamaProcess!.executableURL = URL(fileURLWithPath: LLAMA_SERVER)
-        llamaProcess!.arguments = ["-m", model.path, "-ngl", "999",
+        llamaProcess!.arguments = ["-m", model.path, "-ngl", useGPU ? "999" : "0",
                                    "--port", "\(LLAMA_PORT)", "--host", "127.0.0.1",
                                    "-n", "200", "--log-disable"]
         llamaProcess!.standardOutput = Pipe()
@@ -789,8 +816,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         log("🚀 Starting whisper-server (small) on :\(WHISPER_PORT)…")
         whisperProcess = Process()
         whisperProcess!.executableURL = URL(fileURLWithPath: WHISPER_SERVER)
-        whisperProcess!.arguments = ["-m", WHISPER_MODEL,
-                                     "--port", "\(WHISPER_PORT)", "--host", "127.0.0.1"]
+        var whisperArgs = ["-m", WHISPER_MODEL, "--port", "\(WHISPER_PORT)", "--host", "127.0.0.1"]
+        if !useGPU { whisperArgs.append("--no-gpu") }
+        whisperProcess!.arguments = whisperArgs
         whisperProcess!.standardOutput = Pipe()
         whisperProcess!.standardError  = Pipe()
         try? whisperProcess!.run()
@@ -924,6 +952,29 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 self.itemWhisperToggle.title = "  ⏳ Starting…"
             }
             DispatchQueue.global(qos: .background).async { self.startWhisperServer() }
+        }
+    }
+
+    // ── GPU toggle ─────────────────────────────────────────────────────────────
+    @objc func toggleGPU() {
+        useGPU = !useGPU
+        itemGPUToggle.title = useGPU ? "  ⚡ GPU: On" : "  ⚪ GPU: Off"
+        log("🖥️ GPU acceleration \(useGPU ? "enabled" : "disabled") — restarting servers…")
+        DispatchQueue.main.async {
+            self.itemLlama.title   = "  ⏳ LLM restarting…"
+            self.itemWhisper.title = "  ⏳ Whisper restarting…"
+        }
+        whisperProcess?.terminate(); whisperProcess = nil
+        pkillByName("whisper-server")
+        llamaProcess?.terminate(); llamaProcess = nil
+        pkillByName("llama-server")
+        DispatchQueue.global(qos: .background).async {
+            Thread.sleep(forTimeInterval: 1)
+            self.startWhisperServer()
+        }
+        DispatchQueue.global(qos: .background).async {
+            Thread.sleep(forTimeInterval: 1)
+            self.startLlamaServer()
         }
     }
 
@@ -1099,7 +1150,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         recProcess = Process()
         recProcess!.executableURL = URL(fileURLWithPath: REC_BIN)
-        recProcess!.arguments = [AUDIO_FILE, "rate", "16000", "channels", "1", "trim", "0", "60"]
+        recProcess!.arguments = ["-b", "16", AUDIO_FILE, "rate", "16000", "channels", "1", "trim", "0", "60"]
         recProcess!.standardOutput = Pipe()
         recProcess!.standardError  = Pipe()
         try? recProcess!.run()


### PR DESCRIPTION
## Summary
- Fixed whisper-server and llama-server returning empty results on Intel Macs due to Metal GPU backend bug (Intel Iris 655)
- Added `--no-gpu` flag to whisper-server and dynamic `-ngl` to llama-server based on GPU setting
- Added GPU on/off toggle to the menu bar with preference persistence via UserDefaults
- Fixed Piper TTS fallback — was silently failing due to hardcoded `/usr/local/bin/python3` path
- Fixed `rec` recording 32-bit PCM instead of 16-bit (added `-b 16` flag)
- Updated installer to auto-detect Apple Silicon vs Intel and set safe GPU defaults
- Installer now finds the correct python3 with pip and writes path to `~/.raju/python3_bin`

## Test plan
- [ ] App starts and both servers launch on Intel Mac
- [ ] Voice recording transcribes correctly via whisper
- [ ] LLM returns responses
- [ ] TTS speaks responses (piper or fallback to `say`)
- [ ] GPU toggle in menu restarts servers with correct flags
- [ ] install.sh sets correct GPU defaults for arm64 and x86_64

🤖 Generated with [Claude Code](https://claude.com/claude-code)